### PR TITLE
refactor:リンターエラー回避のため、utils.hに前方宣言を追加

### DIFF
--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: hmaruyam <hmaruyam@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/16 16:18:32 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/03 11:46:30 by hmaruyam         ###   ########.fr       */
+/*   Updated: 2025/10/05 20:00:13 by hmaruyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,21 +19,23 @@
 # include <string.h>
 # include <unistd.h>
 
-void		free_args(char **args);
-void		free_str_wrapper(void *str);
-void		free_str(char *str);
+typedef struct s_pipeline	t_pipeline;
 
-void		close_heredoc(t_list *cmd_lst);
-void		close_pipes(int **pipes, int n);
+void						free_args(char **args);
+void						free_str_wrapper(void *str);
+void						free_str(char *str);
 
-t_status	add_newlst(t_list **head, void *content);
+void						close_heredoc(t_list *cmd_lst);
+void						close_pipes(int **pipes, int n);
 
-void	print_error_msg(char *context, t_status status);
-void	assert_error_lst(t_list *lst, char *context, t_status status,
-			void (*del)(void *));
-void	assert_error_parent(t_pipeline *pipeline, char *context,
-			t_status status);
-void	exit_error(t_pipeline *pipeline, char *context, t_status status,
-			int exit_status);
+t_status					add_newlst(t_list **head, void *content);
+
+void						print_error_msg(char *context, t_status status);
+void						assert_error_lst(t_list *lst, char *context,
+								t_status status, void (*del)(void *));
+void						assert_error_parent(t_pipeline *pipeline,
+								char *context, t_status status);
+void						exit_error(t_pipeline *pipeline, char *context,
+								t_status status, int exit_status);
 
 #endif


### PR DESCRIPTION
## 変更点
t_pipelineを使用しているとリンターエラーがでるので前方宣言で解消

親子関係は
common < utils < (builtin、executor、parserなどの機能）<minishell
のイメージを持ってます

## 懸念点
