### PR TITLE
#131 =がないときの挙動を修正

### DIFF
--- a/srcs/env/env_utils.c
+++ b/srcs/env/env_utils.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/30 14:27:13 by hmaruyam          #+#    #+#             */
-/*   Updated: 2025/10/08 22:39:22 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/08 22:47:53 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,6 @@ t_status	replace_env_value(t_env *env, char *line)
 			new_value = ft_strdup("");
 		else
 			return (SUCCESS);
-		//env->valueがもともとnullで、今回もイコールなしなので何も入れない
 	}
 	else
 		new_value = ft_strdup(line + key_len + 1);


### PR DESCRIPTION
## 変更点
env設定時に=がなかったらNULL、合ったら空文字列に変更。
すでに環境変数が存在して、置き換えるものが=なしだったら空文字列にする。

## 懸念点
空文字列なのかnullなのかちゃんとチェックするの面倒でさぼっちゃってるので使ってみて欲しい。