### PR TITLE
#162 valueがnullの時参照しないように修正

### DIFF
--- a/srcs/env/pack_env.c
+++ b/srcs/env/pack_env.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/04 02:14:31 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/10 19:59:47 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/13 16:19:47 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,12 +14,15 @@
 
 int	count_env_lst(t_list *env_lst)
 {
-	int	n;
+	int		n;
+	t_env	*env;
 
 	n = 0;
 	while (env_lst)
 	{
-		n++;
+		env = env_lst->content;
+		if (env->value)
+			n++;
 		env_lst = env_lst->next;
 	}
 	return (n);
@@ -40,14 +43,17 @@ char	**pack_env(t_list *env_lst)
 	while (env_lst)
 	{
 		env = env_lst->content;
-		envp[i] = pack_line(env->key, env->value);
-		if (!envp[i])
+		if (env->value)
 		{
-			free_args(envp);
-			return (NULL);
+			envp[i] = pack_line(env->key, env->value);
+			if (!envp[i])
+			{
+				free_args(envp);
+				return (NULL);
+			}
+			i++;
 		}
 		env_lst = env_lst->next;
-		i++;
 	}
 	return (envp);
 }


### PR DESCRIPTION
## 変更点
- pack_envでvalueがnullのときpackしないように修正

## 懸念点
- 取りこぼしないかな。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 環境変数に値がない項目を実行時に組み立て対象から自動的に除外するよう改善しました。これにより、空の環境エントリが混入して起こりうる予期しない挙動やクラッシュを防止し、起動やコマンド実行の安定性が向上します。
  * 生成途中でのメモリ確保失敗時に、不要なエントリを作成せず適切に解放して終了する動作を明確化。異常系でのリソースリークや不整合の発生リスクを低減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->