### PR TITLE
#171 exit_error内部でget_exit_statusを呼び出してexit statusを判定するようにした

### DIFF
--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/16 16:18:32 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/13 15:12:35 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/13 18:20:48 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ int							assert_error_lst(t_list *lst, char *context,
 int							assert_error_parent(t_pipeline *pipeline,
 								char *context, t_status status);
 void						exit_error(t_pipeline *pipeline, char *context,
-								t_status status, int exit_status);
+								t_status status);
 void						exit_success(t_pipeline *pipeline);
 
 #endif

--- a/srcs/executor/run_in_child.c
+++ b/srcs/executor/run_in_child.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/16 01:08:34 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/07 23:48:59 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/13 18:22:05 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,19 +33,19 @@ t_cmd	*get_cmd_from_lst(t_list *head, int target)
 void	handle_redir_err(t_pipeline *pipeline, t_redir_err err)
 {
 	if (err.status == ERR_FILE)
-		exit_error(pipeline, err.redir_err->value, ERR_FILE, EXIT_FAILURE);
+		exit_error(pipeline, err.redir_err->value, ERR_FILE);
 	else if (err.status == ERR_DUP)
-		exit_error(pipeline, "dup", ERR_SYSTEM, EXIT_FAILURE);
+		exit_error(pipeline, "dup", ERR_SYSTEM);
 	else if (err.status == ERR_AMB_REDIR)
-		exit_error(pipeline, err.redir_err->value, ERR_AMB_REDIR, EXIT_FAILURE);
+		exit_error(pipeline, err.redir_err->value, ERR_AMB_REDIR);
 }
 
 void	handle_execve_error(t_pipeline *pipeline, t_cmd *cmd)
 {
 	if (errno == EISDIR)
-		exit_error(pipeline, cmd->args[0], ERR_ISDIR, 126);
+		exit_error(pipeline, cmd->args[0], ERR_ISDIR);
 	else
-		exit_error(pipeline, cmd->args[0], ERR_ERRNO, 126);
+		exit_error(pipeline, cmd->args[0], ERR_ERRNO);
 }
 
 void	run_in_child(t_minishell *minishell, t_pipeline *pipeline, int pos)
@@ -61,7 +61,7 @@ void	run_in_child(t_minishell *minishell, t_pipeline *pipeline, int pos)
 	status = pipe_duplicate(pipeline, pos);
 	close_pipes(pipeline->pipes, pipeline->n - 1);
 	if (status != SUCCESS)
-		exit_error(pipeline, "dup", status, EXIT_FAILURE);
+		exit_error(pipeline, "dup", status);
 	err.status = SUCCESS;
 	err.redir_err = NULL;
 	redirect(minishell, cmd->redir_lst, &err);
@@ -80,19 +80,19 @@ void	run_in_child(t_minishell *minishell, t_pipeline *pipeline, int pos)
 	if (status != SUCCESS)
 	{
 		if (status == ERR_SYSTEM)
-			exit_error(pipeline, "malloc", status, EXIT_FAILURE);
+			exit_error(pipeline, "malloc", status);
 		else
-			exit_error(pipeline, cmd->args[0], status, 127);
+			exit_error(pipeline, cmd->args[0], status);
 	}
 	if (stat(cmd->path, &st_buf) == -1)
-		exit_error(pipeline, cmd->path, ERR_ERRNO, 127);
+		exit_error(pipeline, cmd->path, ERR_ERRNO);
 	if (S_ISDIR(st_buf.st_mode))
-		exit_error(pipeline, cmd->path, ERR_ISDIR, 126);
+		exit_error(pipeline, cmd->path, ERR_ISDIR);
 	if (access(cmd->path, X_OK) == -1)
-		exit_error(pipeline, cmd->path, ERR_SYSTEM, 126);
+		exit_error(pipeline, cmd->path, ERR_SYSTEM);
 	envp = pack_env(minishell->env_lst);
 	if (!envp)
-		exit_error(pipeline, "malloc", ERR_MALLOC, EXIT_FAILURE);
+		exit_error(pipeline, "malloc", ERR_MALLOC);
 	if (execve(cmd->path, cmd->args, envp) == -1)
 	{
 		free_args(envp);

--- a/srcs/utils/exit.c
+++ b/srcs/utils/exit.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/16 23:45:13 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/13 16:07:56 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/13 18:20:43 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,12 +91,11 @@ int	assert_error_parent(t_pipeline *pipeline, char *context, t_status status)
 	return (get_exit_status(status));
 }
 
-void	exit_error(t_pipeline *pipeline, char *context, t_status status,
-		int exit_status)
+void	exit_error(t_pipeline *pipeline, char *context, t_status status)
 {
 	print_error_msg(context, status);
 	free_pipeline(pipeline);
-	exit(exit_status);
+	exit(get_exit_status(status));
 }
 
 void	exit_success(t_pipeline *pipeline)


### PR DESCRIPTION
## 変更点
- exit_errorのexit_status引数を削除して、t_statusからexit statusを判定できるようにしました。

## 懸念点
- base branchはmainじゃないです

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * なし

* バグ修正
  * エラー発生時の終了コードをエラー種別に基づいて統一し、スクリプトやパイプラインでの挙動を安定化

* リファクタ
  * 内部のエラー処理を簡素化し、重複した終了コード指定を解消

<!-- end of auto-generated comment: release notes by coderabbit.ai -->