### PR TITLE
#176 子プロセスのexit時にenv_lstのfreeを追加

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execute.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hmaruyam <hmaruyam@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/16 01:11:45 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/11 01:39:11 by hmaruyam         ###   ########.fr       */
+/*   Updated: 2025/10/14 15:39:35 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,7 +36,8 @@ typedef enum e_command_type
 
 void			execute(t_minishell *minishell, t_pipeline *pipeline);
 
-void			handle_redir_err(t_pipeline *pipeline, t_redir_err err);
+void			handle_redir_err(t_minishell *minishell, t_pipeline *pipeline,
+					t_redir_err err);
 void			run_in_child(t_minishell *minishell, t_pipeline *pipeline,
 					int pos);
 void			child_process(t_minishell *minishell, t_pipeline *pipeline);

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/16 16:18:32 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/13 18:20:48 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/14 15:34:59 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,8 +40,10 @@ int							assert_error_lst(t_list *lst, char *context,
 								t_status status, void (*del)(void *));
 int							assert_error_parent(t_pipeline *pipeline,
 								char *context, t_status status);
-void						exit_error(t_pipeline *pipeline, char *context,
+void						exit_error(t_minishell *minishell,
+								t_pipeline *pipeline, char *context,
 								t_status status);
-void						exit_success(t_pipeline *pipeline);
+void						exit_success(t_minishell *minishell,
+								t_pipeline *pipeline);
 
 #endif

--- a/srcs/executor/run_in_child.c
+++ b/srcs/executor/run_in_child.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/16 01:08:34 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/13 18:22:05 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/14 15:38:42 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,22 +30,22 @@ t_cmd	*get_cmd_from_lst(t_list *head, int target)
 		return (lst->content);
 }
 
-void	handle_redir_err(t_pipeline *pipeline, t_redir_err err)
+void	handle_redir_err(t_minishell *minishell, t_pipeline *pipeline, t_redir_err err)
 {
 	if (err.status == ERR_FILE)
-		exit_error(pipeline, err.redir_err->value, ERR_FILE);
+		exit_error(minishell, pipeline, err.redir_err->value, ERR_FILE);
 	else if (err.status == ERR_DUP)
-		exit_error(pipeline, "dup", ERR_SYSTEM);
+		exit_error(minishell, pipeline, "dup", ERR_SYSTEM);
 	else if (err.status == ERR_AMB_REDIR)
-		exit_error(pipeline, err.redir_err->value, ERR_AMB_REDIR);
+		exit_error(minishell, pipeline, err.redir_err->value, ERR_AMB_REDIR);
 }
 
-void	handle_execve_error(t_pipeline *pipeline, t_cmd *cmd)
+void	handle_execve_error(t_minishell *minishell, t_pipeline *pipeline, t_cmd *cmd)
 {
 	if (errno == EISDIR)
-		exit_error(pipeline, cmd->args[0], ERR_ISDIR);
+		exit_error(minishell, pipeline, cmd->args[0], ERR_ISDIR);
 	else
-		exit_error(pipeline, cmd->args[0], ERR_ERRNO);
+		exit_error(minishell, pipeline, cmd->args[0], ERR_ERRNO);
 }
 
 void	run_in_child(t_minishell *minishell, t_pipeline *pipeline, int pos)
@@ -61,12 +61,12 @@ void	run_in_child(t_minishell *minishell, t_pipeline *pipeline, int pos)
 	status = pipe_duplicate(pipeline, pos);
 	close_pipes(pipeline->pipes, pipeline->n - 1);
 	if (status != SUCCESS)
-		exit_error(pipeline, "dup", status);
+		exit_error(minishell, pipeline, "dup", status);
 	err.status = SUCCESS;
 	err.redir_err = NULL;
 	redirect(minishell, cmd->redir_lst, &err);
 	if (err.status != SUCCESS)
-		handle_redir_err(pipeline, err);
+		handle_redir_err(minishell, pipeline, err);
 	type = scan_command_type(cmd);
 	if (type != EXTERNAL && type != NO_CMD)
 	{
@@ -75,27 +75,27 @@ void	run_in_child(t_minishell *minishell, t_pipeline *pipeline, int pos)
 		exit(minishell->last_status);
 	}
 	else if (type == NO_CMD)
-		exit_success(pipeline);
+		exit_success(minishell, pipeline);
 	status = resolve_command_path(cmd, minishell->env_lst);
 	if (status != SUCCESS)
 	{
 		if (status == ERR_SYSTEM)
-			exit_error(pipeline, "malloc", status);
+			exit_error(minishell, pipeline, "malloc", status);
 		else
-			exit_error(pipeline, cmd->args[0], status);
+			exit_error(minishell, pipeline, cmd->args[0], status);
 	}
 	if (stat(cmd->path, &st_buf) == -1)
-		exit_error(pipeline, cmd->path, ERR_ERRNO);
+		exit_error(minishell, pipeline, cmd->path, ERR_ERRNO);
 	if (S_ISDIR(st_buf.st_mode))
-		exit_error(pipeline, cmd->path, ERR_ISDIR);
+		exit_error(minishell, pipeline, cmd->path, ERR_ISDIR);
 	if (access(cmd->path, X_OK) == -1)
-		exit_error(pipeline, cmd->path, ERR_SYSTEM);
+		exit_error(minishell, pipeline, cmd->path, ERR_SYSTEM);
 	envp = pack_env(minishell->env_lst);
 	if (!envp)
-		exit_error(pipeline, "malloc", ERR_MALLOC);
+		exit_error(minishell, pipeline, "malloc", ERR_MALLOC);
 	if (execve(cmd->path, cmd->args, envp) == -1)
 	{
 		free_args(envp);
-		handle_execve_error(pipeline, cmd);
+		handle_execve_error(minishell, pipeline, cmd);
 	}
 }

--- a/srcs/utils/exit.c
+++ b/srcs/utils/exit.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/16 23:45:13 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/13 18:20:43 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/14 15:33:51 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,15 +91,17 @@ int	assert_error_parent(t_pipeline *pipeline, char *context, t_status status)
 	return (get_exit_status(status));
 }
 
-void	exit_error(t_pipeline *pipeline, char *context, t_status status)
+void	exit_error(t_minishell *minishell, t_pipeline *pipeline, char *context, t_status status)
 {
 	print_error_msg(context, status);
 	free_pipeline(pipeline);
+	ft_lstclear(&(minishell->env_lst), free_env_wrapper);
 	exit(get_exit_status(status));
 }
 
-void	exit_success(t_pipeline *pipeline)
+void	exit_success(t_minishell *minishell, t_pipeline *pipeline)
 {
 	free_pipeline(pipeline);
+	ft_lstclear(&(minishell->env_lst), free_env_wrapper);
 	exit(0);
 }


### PR DESCRIPTION
## 変更点
子プロセスがexitするときにenv_lstをfreeしました。

## 懸念点
とりこぼしないかな。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - なし

- バグ修正
  - プロセス終了時のリソース解放を強化し、メモリリークや残存状態を防止。
  - リダイレクトやコマンド実行時のエラー処理を改善し、予期せぬ終了やハングを低減。

- リファクタ
  - エラーハンドリング経路と状態管理を整理し、一貫性と安定性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->