### PR TITLE
#178 export引数なしでアンダースコアを表示しないように修正

### DIFF
--- a/srcs/builtins/builtin_export_no_args.c
+++ b/srcs/builtins/builtin_export_no_args.c
@@ -21,6 +21,11 @@ static void	print_no_args(t_list **env_array, size_t env_count)
 	while (i < env_count)
 	{
 		env = (t_env *)(env_array[i]->content);
+		if (ft_strcmp(env->key, "_") == 0)
+		{
+			i++;
+			continue ;
+		}
 		ft_putstr_fd("declare -x ", STDOUT_FILENO);
 		ft_putstr_fd(env->key, STDOUT_FILENO);
 		if (env->value)


### PR DESCRIPTION
## 変更点
タイトル通り
## 懸念点
特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 不具合修正
  - export（引数なし）の出力から「_」環境変数を除外。不要な項目が表示される問題を解消し、他の環境変数の表示や挙動には影響しません。
  - 一覧表示の一貫性と可読性を向上。
  - これにより、declare -x の結果が期待どおりの内容になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->