### PR TITLE
#185 アンダースコアの実装

### DIFF
--- a/srcs/executor/execute.c
+++ b/srcs/executor/execute.c
@@ -6,7 +6,7 @@
 /*   By: hmaruyam <hmaruyam@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/03 00:38:36 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/15 14:22:13 by hmaruyam         ###   ########.fr       */
+/*   Updated: 2025/10/15 14:31:29 by hmaruyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,6 +60,7 @@ void	execute(t_minishell *minishell, t_pipeline *pipeline)
 	t_status		status;
 	char			*last_arg;
 
+	status = SUCCESS;
 	if (pipeline->n != 1)
 	{
 		child_process(minishell, pipeline);
@@ -90,6 +91,6 @@ void	execute(t_minishell *minishell, t_pipeline *pipeline)
 	status = add_env(&(minishell->env_lst), "_", last_arg);
 	free(last_arg);
 	if (status == ERR_SYSTEM)
-		minishell->last_status = assert_error_parent(pipeline, "malloc",
+		minishell->last_status = assert_error_parent(NULL, "malloc",
 				ERR_SYSTEM);
 }


### PR DESCRIPTION
## 変更点
envとecho $_でアンダースコアを扱えるようにしました。

コマンド実行直前はフルパスで、直後に最後の引数（リダイレクションは関係なくargs_lstの最後）をいれます。
NO_CMDは空文字が入ります。
コマンド実行直前の_を確認できるのはenvだけだからここまで労力かけなくても良かった感。

executeの中でコマンドの数が1つじゃなかったときchild呼んで早期リターンするように修正してます。

## 懸念点
セグフォの前科があるので怖い。
今回はchild_processでfree(pipeline)呼んだあとにcmdの中身を確認しようとしてたのでセグフォしました。

path.cのパス探す関数がERR_SYSTEMのままなので、ERR_MALLOCに統一したい気持ち。

executorの中身をすべて理解できてないので整合性とれてないとこあったら怖いです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新機能
  * 環境変数「_」の挙動を強化：実行中はコマンドのパスを保持し、実行後は最後の引数へ自動更新するように統一。

* バグ修正
  * パイプライン実行の制御を見直し、単一／複数コマンドでの親子プロセス処理を安定化。
  * メモリ確保失敗時の終了ステータス報告を改善し、最後の引数の解放でメモリリークを防止。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->