### PR TITLE
#188 builtinでのft_put系をprintfに変更

### DIFF
--- a/srcs/builtins/builtin_cd.c
+++ b/srcs/builtins/builtin_cd.c
@@ -103,6 +103,6 @@ int	builtin_cd(t_minishell *minishell, char **args)
 	if (!target_path)
 		return (1);
 	if (args[1] && ft_strncmp(args[1], "-", 2) == 0)
-		ft_putendl_fd(target_path, STDOUT_FILENO);
+		printf("%s\n", target_path);
 	return (perform_chdir(&minishell->env_lst, target_path));
 }

--- a/srcs/builtins/builtin_echo.c
+++ b/srcs/builtins/builtin_echo.c
@@ -41,12 +41,12 @@ int	builtin_echo(char **args)
 	}
 	while (args[i])
 	{
-		ft_putstr_fd(args[i], STDOUT_FILENO);
+		printf("%s", args[i]);
 		if (args[i + 1])
-			ft_putchar_fd(' ', STDOUT_FILENO);
+			printf(" ");
 		i++;
 	}
 	if (!n_option)
-		ft_putchar_fd('\n', STDOUT_FILENO);
+		printf("\n");
 	return (0);
 }

--- a/srcs/builtins/builtin_env.c
+++ b/srcs/builtins/builtin_env.c
@@ -22,11 +22,7 @@ int	builtin_env(t_minishell *minishell)
 	{
 		env = (t_env *)(cur_node->content);
 		if (env->value)
-		{
-			ft_putstr_fd(env->key, STDOUT_FILENO);
-			ft_putstr_fd("=", STDOUT_FILENO);
-			ft_putendl_fd(env->value, STDOUT_FILENO);
-		}
+			printf("%s=%s\n", env->key, env->value);
 		cur_node = cur_node->next;
 	}
 	return (0);

--- a/srcs/builtins/builtin_exit.c
+++ b/srcs/builtins/builtin_exit.c
@@ -17,7 +17,7 @@ int	builtin_exit(t_minishell *minishell, char **args, int cmd_count)
 	unsigned char	last_status;
 
 	if (isatty(STDERR_FILENO) && isatty(STDIN_FILENO) && cmd_count == 1)
-		ft_putendl_fd("exit", STDOUT_FILENO);
+		printf("exit\n");
 	if (!args[1])
 	{
 		minishell->should_exit = true;

--- a/srcs/builtins/builtin_export_no_args.c
+++ b/srcs/builtins/builtin_export_no_args.c
@@ -26,15 +26,14 @@ static void	print_no_args(t_list **env_array, size_t env_count)
 			i++;
 			continue ;
 		}
-		ft_putstr_fd("declare -x ", STDOUT_FILENO);
-		ft_putstr_fd(env->key, STDOUT_FILENO);
+		printf("declare -x %s", env->key);
 		if (env->value)
 		{
-			ft_putstr_fd("=\"", STDOUT_FILENO);
+			printf("=\"");
 			print_escape_value(env->value);
-			ft_putstr_fd("\"", STDOUT_FILENO);
+			printf("\"");
 		}
-		ft_putstr_fd("\n", STDOUT_FILENO);
+		printf("\n");
 		i++;
 	}
 }

--- a/srcs/builtins/builtin_export_utils.c
+++ b/srcs/builtins/builtin_export_utils.c
@@ -20,8 +20,8 @@ void	print_escape_value(char *str)
 	while (str[i])
 	{
 		if (str[i] == '\"' || str[i] == '`' || str[i] == '$' || str[i] == '\\')
-			ft_putchar_fd('\\', STDOUT_FILENO);
-		ft_putchar_fd(str[i], STDOUT_FILENO);
+			printf("\\");
+		printf("%c", str[i]);
 		i++;
 	}
 }

--- a/srcs/builtins/builtin_pwd.c
+++ b/srcs/builtins/builtin_pwd.c
@@ -33,7 +33,7 @@ int	builtin_pwd(t_minishell *minishell)
 
 	env_pwd = search_env(minishell->env_lst, "PWD");
 	if (env_pwd && is_pwd_valid(env_pwd))
-		ft_putendl_fd(env_pwd, STDOUT_FILENO);
+		printf("%s\n", env_pwd);
 	else
 	{
 		cwd = getcwd(NULL, 0);
@@ -42,7 +42,7 @@ int	builtin_pwd(t_minishell *minishell)
 			print_error_msg_builtin("pwd", GETCWD_ERR, BLTERR_ERRNO);
 			return (1);
 		}
-		ft_putendl_fd(cwd, STDOUT_FILENO);
+		printf("%s\n", cwd);
 		free(cwd);
 	}
 	return (0);


### PR DESCRIPTION
## 変更点
タイトル通り
## 懸念点


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- リファクタ
  - 複数の組み込みコマンドの標準出力処理を統一。printfベースに置換し、表示内容や改行の挙動は従来どおり。ユーザー向けの動作変更はありませんが、出力の一貫性・可読性・保守性が向上しました（対象: cd, echo, env, exit, export, pwd）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->