### PR TITLE
#183 add_envをrename

### DIFF
--- a/includes/env.h
+++ b/includes/env.h
@@ -34,7 +34,7 @@ char		*pack_line(char *key, char *value);
 int			is_valid_key_first_char(char c);
 int			is_valid_key_char(char c);
 
-t_status	add_env(t_list **head, char *key, char *value);
+t_status	process_env_key_value(t_list **head, char *key, char *value);
 void		remove_env(t_list **head, char *key);
 
 char		*search_env(t_list *env_lst, char *key);

--- a/srcs/builtins/builtin_cd.c
+++ b/srcs/builtins/builtin_cd.c
@@ -37,10 +37,10 @@ static int	update_pwd_env(t_list **env_lst, char *old_pwd, char *new_pwd)
 {
 	t_status	status;
 
-	status = add_env(env_lst, "OLDPWD", old_pwd);
+	status = process_env_key_value(env_lst, "OLDPWD", old_pwd);
 	if (status == ERR_MALLOC)
 		return (return_error("malloc", ERR_MALLOC));
-	status = add_env(env_lst, "PWD", new_pwd);
+	status = process_env_key_value(env_lst, "PWD", new_pwd);
 	if (status == ERR_MALLOC)
 		return (return_error("malloc", ERR_MALLOC));
 	return (0);

--- a/srcs/builtins/builtin_export_args.c
+++ b/srcs/builtins/builtin_export_args.c
@@ -25,7 +25,7 @@ static t_status	process_append_arg(t_minishell *minishell, char *key,
 	new_value = ft_strjoin(old_value, to_append_value);
 	if (!new_value)
 		return (ERR_MALLOC);
-	status = add_env(&(minishell->env_lst), key, new_value);
+	status = process_env_key_value(&(minishell->env_lst), key, new_value);
 	free(new_value);
 	return (status);
 }

--- a/srcs/env/env_operation.c
+++ b/srcs/env/env_operation.c
@@ -12,7 +12,7 @@
 
 #include "minishell.h"
 
-t_status	add_env(t_list **head, char *key, char *value)
+t_status	process_env_key_value(t_list **head, char *key, char *value)
 {
 	char		*line;
 	char		*tmp;

--- a/srcs/executor/execute.c
+++ b/srcs/executor/execute.c
@@ -30,7 +30,7 @@ static t_status	set_underscore_for_invocation(t_minishell *minishell,
 		if (underscore_cmd.path)
 			value = underscore_cmd.path;
 	}
-	status = add_env(&(minishell->env_lst), "_", value);
+	status = process_env_key_value(&(minishell->env_lst), "_", value);
 	if (type == EXTERNAL && value != cmd->args[0])
 		free(value);
 	return (status);
@@ -88,7 +88,7 @@ void	execute(t_minishell *minishell, t_pipeline *pipeline)
 		child_process(minishell, pipeline);
 	else
 		run_builtin_in_parent(minishell, pipeline, type);
-	status = add_env(&(minishell->env_lst), "_", last_arg);
+	status = process_env_key_value(&(minishell->env_lst), "_", last_arg);
 	free(last_arg);
 	if (status == ERR_SYSTEM)
 		minishell->last_status = assert_error_parent(NULL, "malloc",

--- a/srcs/expander/remove_quote.c
+++ b/srcs/expander/remove_quote.c
@@ -46,7 +46,7 @@ char	*add_normal_words(int start, int end, char *new, char *old)
 	return (new);
 }
 
-char	*add_env_value(t_minishell *minishell, int *i, char *new, char *old)
+char	*process_env_key_value_value(t_minishell *minishell, int *i, char *new, char *old)
 {
 	char	*expand_str;
 
@@ -81,7 +81,7 @@ char	*handle_double_quote(t_minishell *minishell, char *old, int *i)
 				if (!new)
 					return (NULL);
 			}
-			new = add_env_value(minishell, i, new, old);
+			new = process_env_key_value_value(minishell, i, new, old);
 			if (!new)
 				return (NULL);
 			copied_pos = *i;


### PR DESCRIPTION
## 変更点
add_envをprocess_env_lineと対称的になるように
process_env_key_valueに変更しました
## 懸念点


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- リファクタリング
  - 環境変数の更新処理の名称を整理し、プロジェクト全体で呼び出しを統一。
  - 展開処理における補助関数名を整理し、可読性を向上。
  - 環境変数の更新動作は従来どおりで、挙動変更はありません。

- 雑務
  - インターフェース表記を統一し、将来的な保守性を向上。
  - パフォーマンスや外部仕様への影響はなく、ユーザー向けの変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->