### PR TITLE
#229 sigaction失敗時のハンドリングを削除

### DIFF
--- a/includes/common.h
+++ b/includes/common.h
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/30 13:29:06 by hmaruyam          #+#    #+#             */
-/*   Updated: 2025/10/18 12:49:53 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/26 13:09:33 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,6 @@ typedef enum e_status
 	ERR_PIPE,
 	ERR_FORK,
 	ERR_WAITPID,
-	ERR_SIG,
 	ERR_HEREDOC,
 	ERR_NOKEY,
 	RCV_SIGINT,

--- a/includes/signals.h
+++ b/includes/signals.h
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/17 02:45:41 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/17 14:32:18 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/26 12:52:07 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,10 @@
 
 extern volatile sig_atomic_t	g_sig;
 
-t_status						set_signal_interactive(void);
-t_status						set_signal_noninteractive(void);
-t_status						set_signal_heredoc(void);
-t_status						set_signal_default(void);
-t_status						set_signal_wait_child(void);
+void						set_signal_interactive(void);
+void						set_signal_noninteractive(void);
+void						set_signal_heredoc(void);
+void						set_signal_default(void);
+void						set_signal_wait_child(void);
 
 #endif

--- a/srcs/executor/process.c
+++ b/srcs/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/16 23:42:22 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/17 19:14:30 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/26 13:08:26 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,8 +28,8 @@ void	wait_child(t_minishell *minishell, t_pipeline *pipeline, pid_t *pids,
 		free(pids);
 		return ;
 	}
-	if (isatty(STDIN_FILENO) && set_signal_wait_child() != SUCCESS)
-		print_error_msg("sigaction", ERR_SIG);
+	if (isatty(STDIN_FILENO))
+		set_signal_wait_child();
 	while (i < pids_count)
 	{
 		if (waitpid(pids[i], &status, 0) == -1)
@@ -61,11 +61,8 @@ void	wait_child(t_minishell *minishell, t_pipeline *pipeline, pid_t *pids,
 	}
 	else
 		minishell->last_status = 1;
-	if (isatty(STDIN_FILENO) && set_signal_interactive() != SUCCESS)
-	{
-		print_error_msg("sigaction", ERR_SIG);
-		minishell->should_exit = 1;
-	}
+	if (isatty(STDIN_FILENO))
+		set_signal_interactive();
 	free(pids);
 }
 
@@ -82,8 +79,7 @@ int	fork_all_children(t_minishell *minishell, t_pipeline *pipeline, pid_t *pids)
 		if (pids[i] == 0)
 		{
 			free(pids);
-			if (set_signal_default() != SUCCESS)
-				exit_error(minishell, pipeline, "sigaction", ERR_SIG);
+			set_signal_default();
 			run_in_child(minishell, pipeline, i);
 		}
 		i++;

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/06 16:54:01 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/18 12:53:23 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/26 13:12:56 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,14 +28,9 @@ int	main(int argc, char **argv, char **envp)
 	(void)argc;
 	(void)argv;
 	if (isatty(STDIN_FILENO))
-		status = set_signal_interactive();
+		set_signal_interactive();
 	else
-		status = set_signal_noninteractive();
-	if (status != SUCCESS)
-	{
-		print_error_msg("sigaction", status);
-		exit(1);
-	}
+		set_signal_noninteractive();
 	minishell.should_exit = 0;
 	minishell.last_status = 0;
 	minishell.env_lst = env_init(&minishell, envp);

--- a/srcs/redirection/heredoc.c
+++ b/srcs/redirection/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/04 17:15:39 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/18 13:16:55 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/26 13:09:19 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -151,11 +151,8 @@ t_status	read_heredoc(t_minishell *minishell, t_pipeline *pipeline)
 
 	status = SUCCESS;
 	cur_node = pipeline->cmd_lst;
-	if (isatty(STDIN_FILENO) && set_signal_heredoc() != SUCCESS)
-	{
-		minishell->last_status = error_parent(pipeline, "sigaction", ERR_SIG);
-		return (ERR_SIG);
-	}
+	if (isatty(STDIN_FILENO))
+		set_signal_heredoc();
 	while (cur_node)
 	{
 		cmd = cur_node->content;
@@ -179,15 +176,7 @@ t_status	read_heredoc(t_minishell *minishell, t_pipeline *pipeline)
 		}
 		cur_node = cur_node->next;
 	}
-	if (isatty(STDIN_FILENO) && set_signal_interactive() != SUCCESS)
-	{
-		if (status == SUCCESS)
-			minishell->last_status = error_parent(pipeline, "sigaction",
-					ERR_SIG);
-		else
-			minishell->last_status = error_parent(NULL, "sigaction", ERR_SIG);
-		minishell->should_exit = 1;
-		return (ERR_SIG);
-	}
+	if (isatty(STDIN_FILENO))
+		set_signal_interactive();
 	return (status);
 }

--- a/srcs/signals/signal_setup.c
+++ b/srcs/signals/signal_setup.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/17 02:46:49 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/17 14:31:50 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/26 12:51:37 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,59 +31,42 @@ void	sigint_handler_in_heredoc(int signo)
 	write(STDERR_FILENO, "\n", 1);
 }
 
-t_status	set_action(int sig, void (*handler)(int))
+void	set_action(int sig, void (*handler)(int))
 {
 	struct sigaction	sig_act;
 
 	sig_act.sa_handler = handler;
 	sig_act.sa_flags = 0;
 	sigemptyset(&sig_act.sa_mask);
-	if (sigaction(sig, &sig_act, NULL) == -1)
-		return (ERR_SIG);
-	return (SUCCESS);
+	sigaction(sig, &sig_act, NULL);
 }
 
-t_status	set_signal_interactive(void)
+void	set_signal_interactive(void)
 {
-	if (set_action(SIGINT, sigint_handler_in_readline) == ERR_SIG)
-		return (ERR_SIG);
-	if (set_action(SIGQUIT, SIG_IGN) == ERR_SIG)
-		return (ERR_SIG);
-	return (SUCCESS);
+	set_action(SIGINT, sigint_handler_in_readline);
+	set_action(SIGQUIT, SIG_IGN);
 }
 
-t_status	set_signal_noninteractive(void)
+void	set_signal_noninteractive(void)
 {
-	if (set_action(SIGINT, SIG_DFL) == ERR_SIG)
-		return (ERR_SIG);
-	if (set_action(SIGQUIT, SIG_IGN) == ERR_SIG)
-		return (ERR_SIG);
-	return (SUCCESS);
+	set_action(SIGINT, SIG_DFL);
+	set_action(SIGQUIT, SIG_IGN);
 }
 
-t_status	set_signal_heredoc(void)
+void	set_signal_heredoc(void)
 {
-	if (set_action(SIGINT, sigint_handler_in_heredoc) == ERR_SIG)
-		return (ERR_SIG);
-	if (set_action(SIGQUIT, SIG_IGN) == ERR_SIG)
-		return (ERR_SIG);
-	return (SUCCESS);
+	set_action(SIGINT, sigint_handler_in_heredoc);
+	set_action(SIGQUIT, SIG_IGN);
 }
 
-t_status	set_signal_default(void)
+void	set_signal_default(void)
 {
-	if (set_action(SIGINT, SIG_DFL) == ERR_SIG)
-		return (ERR_SIG);
-	if (set_action(SIGQUIT, SIG_DFL) == ERR_SIG)
-		return (ERR_SIG);
-	return (SUCCESS);
+	set_action(SIGINT, SIG_DFL);
+	set_action(SIGQUIT, SIG_DFL);
 }
 
-t_status	set_signal_wait_child(void)
+void	set_signal_wait_child(void)
 {
-	if (set_action(SIGINT, SIG_IGN) == ERR_SIG)
-		return (ERR_SIG);
-	if (set_action(SIGQUIT, SIG_IGN) == ERR_SIG)
-		return (ERR_SIG);
-	return (SUCCESS);
+	set_action(SIGINT, SIG_IGN);
+	set_action(SIGQUIT, SIG_IGN);
 }


### PR DESCRIPTION
## 変更点
- sigactionの戻り値を確認しないように修正しました。
- それに伴ってERR_SIGを削除しました。
- 失敗してもエラーメッセージ出力なしでそのまま続行するようになっています。

## 懸念点
- コンパイルできているので大丈夫だと思うんだけど取りこぼしがないか心配です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * シグナルハンドリングシステムを簡略化しました。不要なエラー報告メカニズムを削除し、シグナル設定処理を無条件で実行するよう改善しました。これにより、コード内部の複雑性が減少し、保守性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->