### PR TITLE
#239 カレントディレクトリ捜索時に./をつけて捜索するように修正

### DIFF
--- a/srcs/executor/path.c
+++ b/srcs/executor/path.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/19 16:32:03 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/17 19:38:23 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/10/31 16:11:01 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ t_status	search_path(t_cmd *cmd, char **paths)
 		if (paths[i][0] != '\0')
 			tmp = ft_strjoin(paths[i], "/");
 		else
-			tmp = ft_strdup(paths[i]);
+			tmp = ft_strjoin("./", paths[i]);
 		if (!tmp)
 			return (ERR_MALLOC);
 		full_path = ft_strjoin(tmp, cmd->args[0]);


### PR DESCRIPTION
## 変更点
- PATH=":", ":/bin"など、':'が区切り文字として使われていない時にカレントディレクトリを捜索しますが、./{入力}として捜索するように修正しました。
- この挙動は以下で確認できます。
```
cd playground
chmod 644 ls
export PATH=":"
ls
```
<img width="424" height="27" alt="image" src="https://github.com/user-attachments/assets/6212da21-f8c8-4dad-a891-1fc9f5037fae" />

bashのこのエラーメッセージはシェルスクリプトと判断して中身を読んだがshebangがないときのエラーメッセージです。

## 懸念点


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * PATH環境変数に空のエントリが含まれている場合のコマンド検索動作を改善しました。空のパス要素がカレントディレクトリを参照する場合の処理が最適化され、コマンドの検索と実行がより正確で一貫性のあるものになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->