### PR TITLE
#266 getcwdのエラーにはminishell:ってつけない

### DIFF
--- a/srcs/builtins/builtin_pwd.c
+++ b/srcs/builtins/builtin_pwd.c
@@ -6,7 +6,7 @@
 /*   By: hmaruyam <hmaruyam@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/02 09:53:08 by hmaruyam          #+#    #+#             */
-/*   Updated: 2025/10/28 18:24:36 by hmaruyam         ###   ########.fr       */
+/*   Updated: 2025/11/02 18:13:34 by hmaruyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,8 @@ int	builtin_pwd(t_minishell *minishell)
 		cwd = getcwd(NULL, 0);
 		if (!cwd)
 		{
-			print_error_msg_builtin("pwd", GETCWD_ERR, BLTERR_ERRNO);
+			ft_dprintf(STDERR_FILENO, "pwd: %s: %s\n", GETCWD_ERR,
+				strerror(errno));
 			return (1);
 		}
 		ft_printf("%s\n", cwd);


### PR DESCRIPTION
## 変更点
タイトル通り
## 懸念点
他にないかな〜ないはず。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * `pwd`コマンドのエラーメッセージ表示を改善しました。失敗時のエラー報告の内部処理を最適化しましたが、ユーザーに対する動作と戻り値は変わりません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->