### PR TITLE
非対話モードでのsyntax errorでexitするように修正

### DIFF
--- a/srcs/lexer/tokenize.c
+++ b/srcs/lexer/tokenize.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/22 11:32:59 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/10/28 00:17:56 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/11/04 17:27:44 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,8 @@ static t_list	*handle_lexer_error(t_minishell *minishell, t_input *input,
 		else
 			minishell->last_status = error_lst(*head, "newline", ERR_QUOTE,
 					free_token_wrapper);
+		if (!isatty(STDIN_FILENO))
+			minishell->should_exit = 1;
 	}
 	return (NULL);
 }

--- a/srcs/parser/parse_error.c
+++ b/srcs/parser/parse_error.c
@@ -6,7 +6,7 @@
 /*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/02 17:23:01 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/11/04 10:58:33 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/11/04 17:29:43 by aomatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,6 +48,8 @@ void	handle_error(t_minishell *minishell, t_list *tok_lst, t_list *head,
 		else
 			minishell->last_status = error_lst(head, "newline", ERR_SYNTAX,
 					free_cmd_ir_wrapper);
+		if (!isatty(STDIN_FILENO))
+			minishell->should_exit = 1;
 	}
 	else if (status == ERR_HD_FILE)
 		minishell->last_status = error_lst(head, HD_FILE_ERR, status,


### PR DESCRIPTION
## 変更点
- 非対話モードでsyntax errorが起きた時にshoule_exit = 1とするようにしました。

## 懸念点


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 非対話的実行環境でのエラー処理を改善しました。字句解析エラーおよび構文解析エラーが発生した場合、適切に終了するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->