### PR TITLE
#330 プロンプトの色表示部分を幅として扱わないように変更

### DIFF
--- a/includes/readline.h
+++ b/includes/readline.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   readline.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aomatsud <aomatsud@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: hmaruyam <hmaruyam@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/15 17:17:56 by aomatsud          #+#    #+#             */
-/*   Updated: 2025/11/06 11:00:20 by aomatsud         ###   ########.fr       */
+/*   Updated: 2025/11/07 02:19:23 by hmaruyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,9 +19,9 @@
 # include <stdio.h>
 # include <unistd.h>
 
-# define PROMPT_PART1_SUCCESS "\033[32mminishell\033[0m ➜ \033[34m\033[1m"
-# define PROMPT_PART1_ERROR "\033[32mminishell\033[0m \033[31m➜\033[0m \033[34m\033[1m"
-# define PROMPT_PART2 "\033[0m $ "
+# define PROMPT_PART1_SUCCESS "\001\033[32m\002minishell\001\033[0m\002 > \001\033[34m\033[1m\002"
+# define PROMPT_PART1_ERROR "\001\033[32m\002minishell\001\033[0m\002 \001\033[31m\002>\001\033[0m\002 \001\033[34m\033[1m\002"
+# define PROMPT_PART2 "\001\033[0m\002 $ "
 
 typedef struct s_input
 {


### PR DESCRIPTION
## 変更点
\033とかのANSIエスケープシーケンスは\001  \002で囲わないと、文字として扱われることがあるっぽい。だからコピペとかしたときにバグってた。
あと→はマルチバイト文字で、環境によって1バイトだったり2バイトだったりしそう。これも幅を崩してた。→から>にかえました。

## 懸念点
">"がリダイレクトといっしょでやだったらかえます。
まだばぐないかこわいよ〜〜

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * シェルプロンプトのターミナル表示を改善しました。プロンプト文字列の処理が改善され、成功時と失敗時の両方で適切に表示されるようになりました。プロンプトシンボルも更新され、より一貫した表示になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->